### PR TITLE
Feature/eu search menu

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -9,7 +9,7 @@ $soft-accent: #cdcdcd;
 $green: #037971;
 
 //mixins
-@mixin cta-button() {
+@mixin cta-buttons() {
 	text-decoration: none;
 	font-family: 'Krona One', sans-serif;
 	font-size: 1.1em;

--- a/src/assets/test-values-skills.tsx
+++ b/src/assets/test-values-skills.tsx
@@ -29,9 +29,7 @@ export const skillsData = [
   'SEO/SEM marketing',
   'cloud and distributed',
   'data presentation'
-].map(skill => (
-  {attribute: skill, checked: false}
-))
+]
 
 export const valuesData = [
   //team values
@@ -82,6 +80,4 @@ export const valuesData = [
   'self-funded',
   'technical founder(s)',
   'PBC / B-CORP'
-].map(skill => (
-  {attribute: skill, checked: false}
-))
+]

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,19 +1,28 @@
-import React from 'react'
-import './App.scss'
+import React, { useState } from 'react'
 import { routes } from '../../routes/index'
 import { Route, Switch } from 'react-router-dom'
 
 import Header from '../../components/Header/Header'
+import { OpenMenuContext } from '../../contexts/index'
+import './App.scss'
 
 const App: React.FC = () => {
+	const [isOpen, setIsOpen] = useState<boolean>(false)
+
   return (
 		<div className="App">
-			<Header />
-      <Switch>
-        {Object.values(routes).map((route:any, index:number) => (
-          <Route key={index} {...route} exact path={route.path} />
-        ))}
-      </Switch>
+			<OpenMenuContext.Provider value={{
+				isOpen,
+				toggleMenu: () => setIsOpen(!isOpen),
+				stateChangeHandler: (newState) => setIsOpen(newState.isOpen)
+			}}>
+				<Header />
+				<Switch>
+					{Object.values(routes).map((route:any, index:number) => (
+						<Route key={index} {...route} exact path={route.path} />
+					))}
+				</Switch>
+			</OpenMenuContext.Provider>
 		</div>
   )
 }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -8,8 +8,6 @@
 	position: fixed;
 	width: 100%;
 
-
-	
 	.header-nav {
 		display: flex;
 		justify-content: space-between;
@@ -53,6 +51,6 @@
 	}
 
 	.bm-item-list {
-		height: min-content;
+		display: flex;
 	}
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,20 +1,27 @@
 import React from 'react'
 import { NavLink, Link } from 'react-router-dom'
 import { slide as Menu } from 'react-burger-menu'
-import './Header.scss'
 
 import Search from '../Search/Search'
+import { OpenMenuContext } from '../../contexts/index'
+import './Header.scss'
 
 const Header: React.FC = () => {
 	return (
 		<header className="Header">
-			<Menu
-				customBurgerIcon={<img src="../search.svg" alt="search icon" />}
-				customCrossIcon={<img src="../close.svg" alt="close icon" />}
-				width="min-content"
-			>
-				<Search />
-			</Menu>
+			<OpenMenuContext.Consumer>
+				{({ isOpen, stateChangeHandler }) => (
+					<Menu
+						customBurgerIcon={<img src="../search.svg" alt="search icon" />}
+						customCrossIcon={<img src="../close.svg" alt="close icon" />}
+						width="min-content"
+						isOpen={isOpen}
+						onStateChange={(state) => stateChangeHandler(state)}
+					>
+						<Search />
+					</Menu>
+				)}
+			</OpenMenuContext.Consumer>
 			<h1><Link to="/">
 				HIRE UP
 			</Link></h1>
@@ -25,6 +32,5 @@ const Header: React.FC = () => {
 		</header>
 	)
 }
-
 
 export default Header

--- a/src/components/Home/Home.scss
+++ b/src/components/Home/Home.scss
@@ -21,6 +21,6 @@
 	align-items: center;
 	
 	a {
-		@include cta-button;
+		@include cta-buttons;
 	}
 }

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+
 import './Home.scss'
+import { OpenMenuContext } from '../../contexts/index'
 
 const Home: React.FC = () => {
 	return (
@@ -10,7 +12,11 @@ const Home: React.FC = () => {
 				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Risus viverra adipiscing at in tellus integer. Tristique sollicitudin nibh sit amet. Habitant morbi tristique senectus et netus et malesuada fames ac. Ornare aenean euismod elementum nisi. Rhoncus aenean vel elit scelerisque mauris.</p>
 			</section>
 			<nav className="cta-buttons">
-				<Link to="/">Find Applicants</Link>
+				<OpenMenuContext.Consumer>
+					{({ toggleMenu }) => (
+						<button className="cta-button" onClick={toggleMenu}>Find Applicants</button>
+					)}
+				</OpenMenuContext.Consumer>
 				<Link to="/">I'm an Applicant</Link>
 			</nav>
 		</main>

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -23,8 +23,3 @@
 .option {
   margin: .2em .2em;
 }
-
-.cta-button { 
-  @include cta-button;
-  color: $main-bg;
-}

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -1,7 +1,7 @@
 @import '../../_variables.scss';
 
 .Search {
-  margin: 6em 2em;
+  margin: 1em 2em;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -9,13 +9,13 @@
 
 .options {
   border: .13em solid $soft-accent;
-  margin: 1em 0;
+  margin: .5em 0;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   flex-wrap: wrap;
   overflow: scroll;
-  height: 25em;
+  height: 20em;
   width: 23em;
   padding: 1em;
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useReducer } from 'react'
+import React, { useReducer } from 'react'
 import { skillsData, valuesData } from '../../assets/test-values-skills'
 import { Redirect } from 'react-router-dom'
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -63,13 +63,13 @@ const Search: React.FC = () => {
 		<form className="Search" onSubmit={runSearch}>
 			<h2>Find Applicants</h2>
 			<label htmlFor="skills-options" className="form-label">
-				What skills are you hiring for?
+				What <span className="accent-text">skills</span> are you hiring for?
 			</label>
 			<section id="skills-options" className="options">
 				{makeOption(state.skills, "skills")}
 			</section>
 			<label htmlFor="values-options" className="form-label">
-				What does your company value?
+				What are your company <span className="accent-text">values</span>?
 			</label>
 			<section id="values-options" className="options">
 				{makeOption(state.values, "values")}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,16 +1,21 @@
-import React, { useReducer } from 'react'
+import React, { useReducer, useEffect } from 'react'
 import { skillsData, valuesData } from '../../assets/test-values-skills'
 import { Redirect } from 'react-router-dom'
 
 import './Search.scss'
 
+type attributeList = {
+	skills: Array<string>
+	values: Array<string>
+}
+
 const initialState = {
-	skills: skillsData,
-	values: valuesData,
+	skills: [],
+	values: [],
 	runSearch: false
 }
 
-function reducer(state:object, update: {type:string, change:any}) {
+function reducer(state:object, update:{type:string, change:any}) {
 	return {
 		...state,
 		[update.type]: update.change
@@ -19,7 +24,25 @@ function reducer(state:object, update: {type:string, change:any}) {
 
 const Search: React.FC = () => {
 	const [state, dispatch] = useReducer(reducer, initialState)
-	
+
+	useEffect(() => {
+		fakeFetch()
+			.then(options => {
+				Object.keys(options).forEach(option => {
+					const checkboxes = options[option as keyof attributeList].map(skill => (
+						{ attribute: skill, checked: false }
+					))
+					dispatch({type: option, change: checkboxes})
+				})
+			})
+	}, [])
+
+	const fakeFetch = async () => {
+		return await {
+			skills: skillsData,
+			values: valuesData
+		}
+	}
 	
 	const updateSelections = (event: {target: HTMLInputElement}, type:string) => {
 		const change:any = state[type]

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+type openStateType = {
+	isOpen: boolean
+	toggleMenu: () => void
+	stateChangeHandler: (value: {isOpen: boolean}) => void
+}
+export const OpenMenuContext = React.createContext<openStateType>({
+	isOpen: false,
+	toggleMenu: () => {},
+	stateChangeHandler: ({}) => {}
+})

--- a/src/index.scss
+++ b/src/index.scss
@@ -32,3 +32,7 @@ h1 {
 	color: $main-bg;
 	border: none;
 }
+
+.accent-text {
+	font-family: 'Krona One', sans-serif;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -27,8 +27,8 @@ h1 {
   z-index: -1;
 }
 
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+.cta-button { 
+  @include cta-buttons;
+	color: $main-bg;
+	border: none;
 }


### PR DESCRIPTION
#### Type of Change Made 
- [ ] bugfix 
- [x] new feature 
- [ ] breaking change 
- [ ] testing 
- [ ] formatting 
- [x] styling
#### What's this PR do?
- Implements `useContext` to have access to state `isOpen` in App in Header and Home components.
- Writes a `fakeFetch` method that will be replaced later with a real fetch method to get all skills and values that currently exist amongst all users in the database.
- Updates the styling on the Menu component (spacing, buttons, keywords)
#### Where should the reviewer start?
1. `src/contexts/index.tsx` - this is where `createContext` defines `OpenMenuContext`.
2. The Provider is declared in `App.tsx`, making the contents in the value prop accessible to the Consumer which is in `Header.tsx` and `Home.tsx`
#### How should this be manually tested?
Play around with opening and closing the menu!
#### Any background context you want to provide?
Line 32 in `Search.tsx` has some new to us syntax. It was discovered in [this](https://www.nadershamma.dev/blog/2019/how-to-access-object-properties-dynamically-using-bracket-notation-in-typescript/) article that in order to use bracket notation with TypeScript, you must define the types in an object.
#### What are the relevant tickets?
- Closes #22 
- Makes progress on #21 
