### PR TITLE
Feature/eu applicant fetch

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -6,7 +6,7 @@ $main-bg: #F6F8F2;
 $text: #333533;
 $accent: #E85D75;
 $soft-accent: #cdcdcd;
-$highlight: #037971;
+$highlight: #6369D1;
 
 //mixins
 @mixin cta-buttons() {

--- a/src/assets/api-calls.tsx
+++ b/src/assets/api-calls.tsx
@@ -1,0 +1,23 @@
+const baseUrl = 'https://hireup-be.herokuapp.com/api/v1'
+
+export const getApplicants = (): Promise<any> => {
+	return fetch(`${baseUrl}/applicants`)
+		.then(response => {
+			if (response.ok) {
+				return response.json()
+			} else {
+				throw response
+			}
+		})
+}
+
+export const getApplicantById = (id: number): Promise<any> => {
+	return fetch(`${baseUrl}/applicants/${id}`)
+		.then(response => {
+			if (response.ok) {
+				return response.json()
+			} else {
+				throw response
+			}
+		})
+}

--- a/src/assets/definitions.tsx
+++ b/src/assets/definitions.tsx
@@ -1,26 +1,30 @@
-import { RouteComponentProps } from 'react-router-dom'
-
-export interface ApplicantCard extends ApplicantResults {
+export interface ApplicantCard extends SearchResponse {
   query: {query: Query}
 }
 
 export interface ApplicantProfile {
-  username:string, bio:string, skills:Array<string>, values:Array<string>
+	username:string,
+	bio:string,
+	skills:Array<string>,
+	values:Array<string>
 }
 
-export interface ApplicantProps extends RouteComponentProps {}
-
-export interface ApplicantResults {
+export interface SearchResponse {
   id: number
   username: string
   bio: string
-  skills: Array<string>
-  values: Array<string>
+  skills: Array<Attribute>
+  values: Array<Attribute>
 }
 
 export type AttributeList = {
-	skills: Array<string>
-	values: Array<string>
+	skills: Array<Attribute>
+	values: Array<Attribute>
+}
+
+export type Attribute = {
+	attribute: string
+	id: number
 }
 
 export type OpenMenuType = {
@@ -32,6 +36,4 @@ export type OpenMenuType = {
 export type Query = {
   skills: Array<{attribute:string, checked:boolean}>
   values: Array<{attribute:string, checked:boolean}>
-} 
-
-export interface SearchRedirectProps extends RouteComponentProps {}
+}

--- a/src/assets/test-values-skills.tsx
+++ b/src/assets/test-values-skills.tsx
@@ -1,5 +1,5 @@
 export const skillsData = [
-  'creativity', 
+  'rails', 
   'communication', 
   'critical thinking', 
   'problem solving', 

--- a/src/assets/test-values-skills.tsx
+++ b/src/assets/test-values-skills.tsx
@@ -29,7 +29,9 @@ export const skillsData = [
   'SEO/SEM marketing',
   'cloud and distributed',
   'data presentation'
-]
+].map((skill, i) => (
+	{ attribute: skill, id: i }
+))
 
 export const valuesData = [
   //team values
@@ -80,4 +82,6 @@ export const valuesData = [
   'self-funded',
   'technical founder(s)',
   'PBC / B-CORP'
-]
+].map((value, i) => (
+	{ attribute: value, id: i }
+))

--- a/src/components/Applicant/Applicant.scss
+++ b/src/components/Applicant/Applicant.scss
@@ -1,0 +1,80 @@
+@import '../../_variables.scss';
+
+.applicant-border {
+  border-right: 2px solid $soft-accent;
+  border-bottom: 2px solid $soft-accent;
+  border-radius: 20px; 
+}
+
+.applicant-profile {
+	display: flex;
+
+}
+
+.applicant-attributes {
+	display: flex;
+	justify-content: space-around;
+}
+
+.applicant-icon {
+	border-left: 2px solid $soft-accent;
+	border-radius: 50%;
+	padding: 1.5em;
+	animation: rubberBand 1s;
+}
+
+@keyframes rubberBand {
+  from {
+    transform: scale3d(1, 1, 1);
+  }
+
+  30% {
+    transform: scale3d(1.25, 0.75, 1);
+  }
+
+  40% {
+    transform: scale3d(0.75, 1.25, 1);
+  }
+
+  50% {
+    transform: scale3d(1.15, 0.85, 1);
+  }
+
+  65% {
+    transform: scale3d(.95, 1.05, 1);
+  }
+
+  75% {
+    transform: scale3d(1.05, .95, 1);
+  }
+
+  to {
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+.username {
+	color: $highlight;
+}
+
+h5 {
+	font-family: 'Krona One', sans-serif;
+	font-size: 1.2em;
+}
+
+.attribute-tag {
+	font-weight: 500;
+	letter-spacing: 1px;
+	border: 2px solid $soft-accent;
+	border-radius: 7px;
+	padding: .2em;
+	
+	&.highlight {
+		color: $main-bg;
+		border-color: $highlight;
+		background-color: $highlight;
+		letter-spacing: 2px;
+	}
+}
+
+

--- a/src/components/Applicant/Applicant.tsx
+++ b/src/components/Applicant/Applicant.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { ApplicantProfile } from '../../assets/definitions'
 import { getApplicantById } from '../../assets/api-calls'
 import { RouteComponentProps } from 'react-router-dom'
+import './Applicant.scss'
 
 const Applicant: React.FC<RouteComponentProps> = (props) => {
   const [applicant, setApplicant] = useState<ApplicantProfile>({username: '', bio: '', skills: [], values: []})
@@ -30,7 +31,7 @@ const Applicant: React.FC<RouteComponentProps> = (props) => {
 
 const determineMatchedAttribute = (attribute: string, keyword: string, props: any):string => {
 		if (props && props.attributeMatches[keyword][0] && props.attributeMatches[keyword][0].attribute === attribute) {
-      return 'attribute-tag-highlight'
+      return 'attribute-tag highlight'
     } else {
       return 'attribute-tag'
 		}
@@ -57,20 +58,30 @@ const determineMatchedAttribute = (attribute: string, keyword: string, props: an
   }
 
   return (
-    <main className="">
-      <img 
-        className="applicant-icon"
-        src={`https://avatars.dicebear.com/api/bottts/${applicant.username}.svg`} 
-        alt={`${applicant.username}'s icon`}
-      />
-      <h2>{applicant.username}</h2> 
-      <p>{applicant.bio}</p>  
-      <div>
-        <h4>Skills</h4>
-        {attributeLists.skillTags}
-        <h4>Values</h4>
-        {attributeLists.valueTags}
-      </div>
+    <main className="Applicant">
+			<span className="applicant-border">
+				<div className="applicant-profile">
+					<img 
+						className="applicant-icon"
+						src={`https://avatars.dicebear.com/api/bottts/${applicant.username}.svg`} 
+						alt={`${applicant.username}'s icon`}
+					/>
+					<div className="applicant-info">
+						<h2 className="username">{applicant.username}</h2> 
+						<p>{applicant.bio}</p>  
+					</div>
+				</div>
+				<div className="applicant-attributes">
+					<div className="attribute-box">
+						<h5>Skills</h5>
+						{attributeLists.skillTags}
+					</div>
+					<div className="attribute-box">
+						<h5>Values</h5>
+						{attributeLists.valueTags}
+					</div>
+				</div>
+			</span>
     </main>
   )
 }

--- a/src/components/Applicant/Applicant.tsx
+++ b/src/components/Applicant/Applicant.tsx
@@ -1,7 +1,10 @@
-import {ApplicantProps, ApplicantProfile } from '../../assets/definitions'
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react'
 
-const Applicant: React.FC<ApplicantProps> = (props) => {
+import { ApplicantProfile } from '../../assets/definitions'
+import { getApplicantById } from '../../assets/api-calls'
+import { RouteComponentProps } from 'react-router-dom'
+
+const Applicant: React.FC<RouteComponentProps> = (props) => {
   const [applicant, setApplicant] = useState<ApplicantProfile>({username: '', bio: '', skills: [], values: []})
 
   const buildApplicant = (info:any) => {
@@ -16,24 +19,17 @@ const Applicant: React.FC<ApplicantProps> = (props) => {
   useEffect(() => {
     if (props.location.state) {
       buildApplicant(props.location.state)
-      console.log(applicant.username)
     } else {
-      fakeFetch()
-        .then(data => buildApplicant(data))
+			const match:any = props.match.params
+			getApplicantById(match.id)
+        .then(response => {
+					buildApplicant(response.data)
+				})
     }
-  }, [props.location.state])
-
-  const fakeFetch = async () => {
-    return await {
-      username: 'Champ',
-      bio: 'I am the best easter egg of them all',
-      skills: ['screens'],
-      values: ['gold']
-    }
-  }
+  }, [props.location.state, props.match.params])
 
 const determineMatchedAttribute = (attribute: string, keyword: string, props: any):string => {
-		if (props.attributeMatches[keyword][0] && props.attributeMatches[keyword][0].attribute === attribute) {
+		if (props && props.attributeMatches[keyword][0] && props.attributeMatches[keyword][0].attribute === attribute) {
       return 'attribute-tag-highlight'
     } else {
       return 'attribute-tag'

--- a/src/components/ApplicantPreview/ApplicantPreview.scss
+++ b/src/components/ApplicantPreview/ApplicantPreview.scss
@@ -8,7 +8,7 @@
   justify-content: center;
 
   &:hover {    
-    .applicant-icon {
+    .preview-icon {
     transform: rotate(0deg);
     animation: roll 3s;
     }
@@ -44,7 +44,7 @@
   border-top: 1px solid $soft-accent;
 }
 
-.applicant-icon {
+.preview-icon {
   width: 7em;
   height: min-content;
   margin: 1em 0 0 2em;

--- a/src/components/ApplicantPreview/ApplicantPreview.tsx
+++ b/src/components/ApplicantPreview/ApplicantPreview.tsx
@@ -29,7 +29,7 @@ const ApplicantPreview: React.FC<ApplicantCard> = (props) => {
     >
         <div className="applicant-cards">
           <img 
-            className="applicant-icon"
+            className="preview-icon"
             src={`https://avatars.dicebear.com/api/bottts/${props.username}.svg`} 
             alt={`${props.username}'s icon`}
           />

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -7,6 +7,7 @@
 	border-bottom: solid .13em $soft-accent;
 	position: fixed;
 	width: 100%;
+	height: 6em;
 
 	.header-nav {
 		display: flex;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -26,8 +26,8 @@ const Header: React.FC = () => {
 				HIRE UP
 			</Link></h1>
 			<nav className="header-nav">
-				<NavLink exact to="/">MY PROFILE</NavLink>
-				<NavLink exact to="/applicant" activeClassName="active">TEST</NavLink>
+				<NavLink exact to="/applicant/:id">MY PROFILE</NavLink>
+				<NavLink exact to="/applicant/:id/inbox">INBOX</NavLink>
 			</nav>
 		</header>
 	)

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -26,9 +26,11 @@ const Search: React.FC = () => {
 		fakeFetch()
 			.then(options => {
 				Object.keys(options).forEach(option => {
-					const checkboxes = options[option as keyof AttributeList].map(skill => (
-						{ attribute: skill, checked: false }
-					))
+					const checkboxes = options[option as keyof AttributeList].map(attribute => {
+						const checkbox = Object.assign(attribute)
+						checkbox.checked = false
+						return checkbox
+					})
 					dispatch({type: option, change: checkboxes})
 				})
 			})

--- a/src/components/SearchResults/SearchResults.scss
+++ b/src/components/SearchResults/SearchResults.scss
@@ -1,6 +1,5 @@
 .search-results {
 	display: grid;
-	margin-top: 450px;
 	grid-template-columns: repeat(2, 1fr);
 	grid-gap: 2.5em;
 }

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -1,26 +1,23 @@
 import React, { useState, useEffect } from 'react'
 
-import { users as fakeUsers} from '../../assets/fake-users'
-import { ApplicantResults, Query, SearchRedirectProps } from '../../assets/definitions'
 import ApplicantPreview from '../ApplicantPreview/ApplicantPreview'
+import { getApplicants } from '../../assets/api-calls'
+import { SearchResponse } from '../../assets/definitions'
+import { RouteComponentProps } from 'react-router-dom'
 import './SearchResults.scss'
 
 
-const SearchResults: React.FC<SearchRedirectProps> = (props) => {
-  const [users, setUsers] = useState<Array<ApplicantResults>>([])
+const SearchResults: React.FC<RouteComponentProps> = (props) => {
+  const [applicants, setApplicants] = useState<Array<SearchResponse>>([])
 
   let query: unknown | any = props.location.state
 
   useEffect(() => {
-    fakeUserFetch(query)
-    .then(data => setUsers(data))
+		getApplicants()
+    	.then(data => setApplicants(data.data))
   }, [query])
-
-  const fakeUserFetch = async (query: Query) => {
-    return await fakeUsers
-  }
   
-  let userData = users.map((user, i) => {
+  let applicantList = applicants.map((user, i) => {
     return ( 
       <ApplicantPreview 
         key={`applicant-preview-${i}`}
@@ -32,10 +29,11 @@ const SearchResults: React.FC<SearchRedirectProps> = (props) => {
         query={query}
       />
     )
-  })
+	})
+	
   return (
     <main className="search-results">
-      {userData}
+      {applicantList}
     </main>
   )
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -25,7 +25,18 @@ h1 {
   bottom: -6px;
   width: 100%;
   font-size: 2.5em;
-  z-index: -1;
+	z-index: -1;
+	
+	animation: 1s slide, 2.5s bounce;
+
+	@keyframes slide {
+		from {
+			bottom: 100px;
+		}
+		to {
+			bottom: -6px;
+		}
+	}
 }
 
 h3 {


### PR DESCRIPTION
#### Type of Change Made 
- [ ] bugfix 
- [x] new feature 
- [ ] breaking change 
- [ ] testing 
- [x] formatting 
- [x] styling
#### What's this PR do?
- Upon load of the Applicant component, it will either fetch an applicant by the id (`getApplicantById` in `api-calls`) based on the path or load an applicant based on props from the ApplicantPreview card.
- Adds styling to the Applicant component
- In Search, the `fakeFetch` has been updated to account for the way the data will come in for search options. We will still need to write a fetch call and add that in when the endpoint is complete.
- Upon load of the SearchResults component, it will fetch all applicants (`getApplicants` in `api-calls`). **This will need to be set on the BE that this fetch call will only return the matched applicants based on the skills and values provided. I believe we will need to send a body with the selected attributes.**
#### Where should the reviewer start?
The bulk of the work was done in `Applicant.tsx` today
#### How should this be manually tested?
Play around on the page!
#### What are the relevant tickets?
Closes #21 Closes #23 Closes #36 Closes #34 
#### Screenshots (if appropriate)
<img src="http://g.recordit.co/bYEoKCSGge.gif" height=auto width=75%/>
